### PR TITLE
Update checkouts_tasks.yml

### DIFF
--- a/requirements/checkouts_tasks.yml
+++ b/requirements/checkouts_tasks.yml
@@ -196,9 +196,9 @@
     if ! (vv git $gargs merge --ff-only $merge );then
       if (LANG=C LC_ALL=C vv git $gargs merge --ff-only $merge 2>&1|egrep -q "fatal");then
         if ! (vv git $gargs rebase $merge);then
-          vv git checkout $gargs HEAD -b backupupgrade-$chrono
+          vv git $gargs checkout HEAD -b backupupgrade-$chrono
           vv git checkout $curbr
-          vv git reset --hard $gargs $merge
+          vv git $gargs reset --hard $merge
         fi
       else
         exit 1


### PR DESCRIPTION
git reset and git checkout do not accept the `-c` options after the keyword (should be set before the checkout/reset keyword)

@see https://gitlab.makina-corpus.net/Terralego/Customers/Auran/auran-back/-/jobs/170125 (private repo) for example:

error is
```
error: unknown switch `c'`
```

in: 

```
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "set -e\n vv() { echo \"${@}\" >&2;\"${@}\"; }\n gargs=$(if [ \"x$(git config user.email)\" = \"x\" ];then echo \"-c user.name=Corpusops -c user.email=xxxxxx@xxxxxx\";fi)\n chrono=$(date '+%F--%H-%M-%S')\n get_git_branch() {\n ( cd \"${1:-$(pwd)}\" &&\\\n git rev-parse --abbrev-ref HEAD | grep -v HEAD || git describe --exact-match HEAD 2> /dev/null || git rev-parse HEAD)\n }\n curbr=$(get_git_branch)\n merge=\"remotes/origin$(if [ \"x${curbr}\" != \"x\" ];then echo \"/${curbr}\";fi)\"\n vv git branch -a\n if ! (vv git $gargs merge --ff-only $merge );then\n if (LANG=C LC_ALL=C vv git $gargs merge --ff-only $merge 2>&1|egrep -q \"fatal\");then\n if ! (vv git $gargs rebase $merge);then\n vv git checkout $gargs HEAD -b backupupgrade-$chrono\n vv git checkout $curbr\n vv git reset --hard $gargs $merge\n fi\n else\n exit 1\n fi\n fi", "delta": "0:00:00.095237", "end": "2020-01-13 14:19:26.134512", "msg": "non-zero return code", "rc": 129, "start": "2020-01-13 14:19:26.039275", "stderr": "git branch -a\ngit -c user.name=Corpusops -c user.email=xxxxxxxxxx@xxxxxxxx merge --ff-only remotes/origin/master\nfatal: refusing to merge unrelated histories\ngit -c user.name=Corpusops -c user.email=xxxxxxxxx@xxxxxxxxx rebase remotes/origin/master\nerror: The following untracked working tree files would be overwritten by checkout:\n\tdocker/2.0-IMAGES.json\nPlease move or remove them before you switch branches.\nAborting\ncould not detach HEAD\ngit checkout -c user.name=Corpusops -c user.email=xxxxxx@xxxxxxx HEAD -b backupupgrade-2020-01-13--14-19-26\nerror: unknown switch `c'\nusage: git checkout [<options>] <branch>\n   or: git checkout [<options>] [<branch>] -- <file>...\n\n    -q, --quiet           suppress progress reporting\n    -b <branch>           create and checkout a new branch\n    -B <branch>           create/reset and checkout a branch\n    -l                    create reflog for new branch\n    --detach              detach HEAD at named commit\n    -t, --track           set upstream info for new branch\n    --orphan <new-branch>\n                          new unparented branch\n    -2, --ours            checkout our version for unmerged files\n    -3, --theirs          checkout their version for unmerged files\n    -f, --force           force checkout (throw away local modifications)\n    -m, --merge           perform a 3-way merge with the new branch\n    --overwrite-ignore    update ignored files (default)\n    --conflict <style>    conflict style (merge or diff3)\n    -p, --patch           select hunks interactively\n    --ignore-skip-worktree-bits\n                          do not limit pathspecs to sparse entries only\n    --ignore-other-worktrees\n                          do not check if another worktree is holding the given ref\n    --recurse-submodules[=<checkout>]\n                          control recursive updating of submodules\n    --progress            force progress reporting", "stderr_lines": ["git branch -a", "git -c user.name=Corpusops -c user.email=xxxxxxxxx@xxxxxxxxxxxxx merge --ff-only remotes/origin/master", "fatal: refusing to merge unrelated histories", "git -c user.name=Corpusops -c user.email=xxxxxxxxxxx@xxxxxxxxxxxx rebase remotes/origin/master", "error: The following untracked working tree files would be overwritten by checkout:", "\tdocker/2.0-IMAGES.json", "Please move or remove them before you switch branches.", "Aborting", "could not detach HEAD", "git checkout -c user.name=Corpusops -c user.email=xxxxxxxx@xxxxxxxxxxx HEAD -b backupupgrade-2020-01-13--14-19-26", "error: unknown switch `c'", "usage: git checkout [<options>] <branch>", "   or: git checkout [<options>] [<branch>] -- <file>...", "", "    -q, --quiet           suppress progress reporting", "    -b <branch>           create and checkout a new branch", "    -B <branch>           create/reset and checkout a branch", "    -l                    create reflog for new branch", "    --detach              detach HEAD at named commit", "    -t, --track           set upstream info for new branch", "    --orphan <new-branch>", "                          new unparented branch", "    -2, --ours            checkout our version for unmerged files", "    -3, --theirs          checkout their version for unmerged files", "    -f, --force           force checkout (throw away local modifications)", "    -m, --merge           perform a 3-way merge with the new branch", "    --overwrite-ignore    update ignored files (default)", "    --conflict <style>    conflict style (merge or diff3)", "    -p, --patch           select hunks interactively", "    --ignore-skip-worktree-bits", "                          do not limit pathspecs to sparse entries only", "    --ignore-other-worktrees", "                          do not check if another worktree is holding the given ref", "    --recurse-submodules[=<checkout>]", "                          control recursive updating of submodules", "    --progress            force progress reporting"], "stdout": "* master\n  remotes/origin/2.0\n  remotes/origin/master\n  remotes/origin/travis\nFirst, rewinding head to replay your work on top of it...", "stdout_lines": ["* master", "  remotes/origin/2.0", "  remotes/origin/master", "  remotes/origin/travis", "First, rewinding head to replay your work on top of it..."]}
```